### PR TITLE
Attach the Request ID to relevant SDK exceptions

### DIFF
--- a/lib/workos/sso.rb
+++ b/lib/workos/sso.rb
@@ -131,10 +131,11 @@ module WorkOS
           return if body['profile']
 
           message = body['message']
+          request_id = response['x-request-id']
         rescue StandardError
           message = 'Something went wrong'
         end
-        raise WorkOS::RequestError, message
+        raise WorkOS::RequestError, "#{message} - request ID: #{request_id}"
       end
     end
   end

--- a/spec/lib/workos/sso_spec.rb
+++ b/spec/lib/workos/sso_spec.rb
@@ -83,7 +83,7 @@ describe WorkOS::SSO do
         stub_request(:post, 'https://api.workos.com/sso/token').
           with(query: query).
           to_return(
-            headers: { 'X-Request-ID' => 'heroku-request-id' },
+            headers: { 'X-Request-ID' => 'request-id' },
             status: 422,
             body: { "message": 'some error message' }.to_json,
           )

--- a/spec/lib/workos/sso_spec.rb
+++ b/spec/lib/workos/sso_spec.rb
@@ -94,7 +94,7 @@ describe WorkOS::SSO do
           described_class.profile(**args)
         end.to raise_error(
           WorkOS::RequestError,
-          'some error message - request ID: heroku-request-id',
+          'some error message - request ID: request-id',
         )
       end
     end
@@ -104,12 +104,13 @@ describe WorkOS::SSO do
         stub_request(:post, 'https://api.workos.com/sso/token').
           with(query: query).
           to_return(
-            status: 201, 
-            headers: { 'X-Request-ID' => 'heroku-request-id' },
+            status: 201,
+            headers: { 'X-Request-ID' => 'request-id' },
             body: {
-            message: "The code '01DVX3C5Z367SFHR8QNDMK7V24'" \
-              ' has expired or is invalid.',
-          }.to_json,)
+              message: "The code '01DVX3C5Z367SFHR8QNDMK7V24'" \
+                ' has expired or is invalid.',
+            }.to_json,
+          )
       end
 
       it 'raises an exception' do
@@ -117,7 +118,7 @@ describe WorkOS::SSO do
           described_class.profile(**args)
         end.to raise_error(
           WorkOS::RequestError,
-          "The code '01DVX3C5Z367SFHR8QNDMK7V24' has expired or is invalid. - request ID: heroku-request-id",
+          "The code '01DVX3C5Z367SFHR8QNDMK7V24' has expired or is invalid. - request ID: request-id",
         )
       end
     end

--- a/spec/lib/workos/sso_spec.rb
+++ b/spec/lib/workos/sso_spec.rb
@@ -83,15 +83,19 @@ describe WorkOS::SSO do
         stub_request(:post, 'https://api.workos.com/sso/token').
           with(query: query).
           to_return(
+            headers: { 'X-Request-ID' => 'heroku-request-id' },
             status: 422,
             body: { "message": 'some error message' }.to_json,
           )
       end
 
-      it 'raises an exception' do
+      it 'raises an exception with request ID' do
         expect do
           described_class.profile(**args)
-        end.to raise_error(WorkOS::RequestError, 'some error message')
+        end.to raise_error(
+          WorkOS::RequestError,
+          'some error message - request ID: heroku-request-id',
+        )
       end
     end
 
@@ -99,7 +103,10 @@ describe WorkOS::SSO do
       before do
         stub_request(:post, 'https://api.workos.com/sso/token').
           with(query: query).
-          to_return(status: 201, body: {
+          to_return(
+            status: 201, 
+            headers: { 'X-Request-ID' => 'heroku-request-id' },
+            body: {
             message: "The code '01DVX3C5Z367SFHR8QNDMK7V24'" \
               ' has expired or is invalid.',
           }.to_json,)
@@ -110,7 +117,7 @@ describe WorkOS::SSO do
           described_class.profile(**args)
         end.to raise_error(
           WorkOS::RequestError,
-          "The code '01DVX3C5Z367SFHR8QNDMK7V24' has expired or is invalid.",
+          "The code '01DVX3C5Z367SFHR8QNDMK7V24' has expired or is invalid. - request ID: heroku-request-id",
         )
       end
     end

--- a/spec/lib/workos/sso_spec.rb
+++ b/spec/lib/workos/sso_spec.rb
@@ -118,7 +118,8 @@ describe WorkOS::SSO do
           described_class.profile(**args)
         end.to raise_error(
           WorkOS::RequestError,
-          "The code '01DVX3C5Z367SFHR8QNDMK7V24' has expired or is invalid. - request ID: request-id",
+          "The code '01DVX3C5Z367SFHR8QNDMK7V24'" \
+          ' has expired or is invalid. - request ID: request-id',
         )
       end
     end


### PR DESCRIPTION
https://app.clubhouse.io/workos/story/1178/ruby-attach-the-request-id-to-relevant-sdk-exceptions

---

Pretty simple! Couple of lines + a spec.

`Net::HTTP` is a little odd in the sense that it downcases headers. All good though:

```ruby
irb(main):015:0>   profile = WorkOS::SSO.profile(
irb(main):016:1*     code: 'foo',
irb(main):017:1*     project_id: PROJECT_ID,
irb(main):018:1*     redirect_uri: REDIRECT_URI
irb(main):019:1>   )
...
WorkOS::RequestError (The code 'foo' has expired or is invalid. - request ID: 7423a232-c8d7-41b5-bb2e-375d6919a019)
```

Totally open to suggestions wrt to the formatting or copy of adding the request ID to the error message. Ruby exceptions just take a string message, nothing formatted like key / value.

@mark I figure this `client` method will become a singleton class in order to support Audit Logs fwiw.