### PR TITLE
Add version header to Ruby SDK requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # workos-rb
 WorkOS official Ruby gem for interacting with WorkOS APIs
 
+[![codecov](https://codecov.io/gh/workos-inc/workos-ruby/branch/master/graph/badge.svg)](https://codecov.io/gh/workos-inc/workos-ruby)
+
 ## Installation
 
 You don't need this source code unless you want to modify the gem. If you just

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-# workos-rb
-WorkOS official Ruby gem for interacting with WorkOS APIs
+# workos-ruby [![codecov](https://codecov.io/gh/workos-inc/workos-ruby/branch/master/graph/badge.svg)](https://codecov.io/gh/workos-inc/workos-ruby)
 
-[![codecov](https://codecov.io/gh/workos-inc/workos-ruby/branch/master/graph/badge.svg)](https://codecov.io/gh/workos-inc/workos-ruby)
+WorkOS official Ruby gem for interacting with WorkOS APIs
 
 ## Installation
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,6 @@
 coverage:
   status:
+    patch: off
     project:
       default:
         target: 90%

--- a/lib/workos/sso.rb
+++ b/lib/workos/sso.rb
@@ -106,7 +106,7 @@ module WorkOS
           code: code,
         )
 
-        response = client.request(Net::HTTP::Post.new("/sso/token?#{query}"))
+        response = client.request(post_request(path: "/sso/token?#{query}"))
         check_and_raise_error(response: response)
 
         WorkOS::Profile.new(response.body)
@@ -122,6 +122,13 @@ module WorkOS
         @client.use_ssl = true
 
         @client
+      end
+
+      sig { params(path: String).returns(Net::HTTP::Post) }
+      def post_request(path:)
+        request = Net::HTTP::Post.new(path)
+        request['X-SDK-VERSION'] = WorkOS::VERSION
+        request
       end
 
       sig { params(response: Net::HTTPResponse).void }

--- a/lib/workos/sso.rb
+++ b/lib/workos/sso.rb
@@ -127,8 +127,20 @@ module WorkOS
       sig { params(path: String).returns(Net::HTTP::Post) }
       def post_request(path:)
         request = Net::HTTP::Post.new(path)
-        request['X-SDK-VERSION'] = WorkOS::VERSION
+        request['User-Agent'] = user_agent
         request
+      end
+
+      sig { returns(String) }
+      def user_agent
+        engine = defined?(::RUBY_ENGINE) ? ::RUBY_ENGINE : 'Ruby'
+
+        [
+          'WorkOS',
+          "#{engine}/#{RUBY_VERSION}",
+          RUBY_PLATFORM,
+          "v#{WorkOS::VERSION}"
+        ].join('; ')
       end
 
       sig { params(response: Net::HTTPResponse).void }

--- a/spec/lib/workos/sso_spec.rb
+++ b/spec/lib/workos/sso_spec.rb
@@ -59,16 +59,25 @@ describe WorkOS::SSO do
         code: args[:code],
         grant_type: 'authorization_code',
         redirect_uri: args[:redirect_uri],
-      }
+    }
     end
+
+    let(:headers) { { 'X-SDK-VERSION' => WorkOS::VERSION }}
 
     context 'with a successful response' do
       let(:body) { File.read("#{SPEC_ROOT}/support/profile.txt") }
 
       before do
         stub_request(:post, 'https://api.workos.com/sso/token').
-          with(query: query).
+          with(query: query, headers: headers).
           to_return(status: 200, body: body)
+      end
+
+      it 'includes the SDK Version header' do
+        profile = described_class.profile(**args)
+
+        expect(a_request(:post, 'https://api.workos.com/sso/token').
+          with(query: query, headers: headers)).to have_been_made
       end
 
       it 'returns a WorkOS::Profile' do
@@ -81,7 +90,7 @@ describe WorkOS::SSO do
     context 'with an unprocessable request' do
       before do
         stub_request(:post, 'https://api.workos.com/sso/token').
-          with(query: query).
+          with(query: query, headers: headers).
           to_return(
             status: 422,
             body: { "message": 'some error message' }.to_json,

--- a/spec/lib/workos/sso_spec.rb
+++ b/spec/lib/workos/sso_spec.rb
@@ -61,8 +61,11 @@ describe WorkOS::SSO do
         redirect_uri: args[:redirect_uri],
       }
     end
-
-    let(:headers) { { 'X-SDK-VERSION' => WorkOS::VERSION } }
+    let(:user_agent) { 'user-agent-string' }
+    let(:headers) { { 'User-Agent' => user_agent } }
+    before do
+      allow(described_class).to receive(:user_agent).and_return(user_agent)
+    end
 
     context 'with a successful response' do
       let(:body) { File.read("#{SPEC_ROOT}/support/profile.txt") }

--- a/spec/lib/workos/sso_spec.rb
+++ b/spec/lib/workos/sso_spec.rb
@@ -59,10 +59,10 @@ describe WorkOS::SSO do
         code: args[:code],
         grant_type: 'authorization_code',
         redirect_uri: args[:redirect_uri],
-    }
+      }
     end
 
-    let(:headers) { { 'X-SDK-VERSION' => WorkOS::VERSION }}
+    let(:headers) { { 'X-SDK-VERSION' => WorkOS::VERSION } }
 
     context 'with a successful response' do
       let(:body) { File.read("#{SPEC_ROOT}/support/profile.txt") }
@@ -74,7 +74,7 @@ describe WorkOS::SSO do
       end
 
       it 'includes the SDK Version header' do
-        profile = described_class.profile(**args)
+        described_class.profile(**args)
 
         expect(a_request(:post, 'https://api.workos.com/sso/token').
           with(query: query, headers: headers)).to have_been_made


### PR DESCRIPTION
https://app.clubhouse.io/workos/story/1162/add-ruby-sdk-version-to-user-agent-header

---

Adds the `'X-SDK-VERSION'` header to outgoing requests (just profile for now with SSO).

Is that the best name for the header?

EDIT:

This now puts the version and some other info (ruby version, ruby platform) in the User Agent:
```
'User-Agent'=>'WorkOS; ruby/2.6.5; x86_64-darwin18; v0.0.2'
```

I cribbed the method from another gem that seemed legit!

I've also removed codecov "patch" checking and added the badge to the README