### PR TITLE
[feature] move query params to body

### DIFF
--- a/lib/workos/sso.rb
+++ b/lib/workos/sso.rb
@@ -106,14 +106,14 @@ module WorkOS
       #
       # @return [WorkOS::Profile]
       def profile(code:, project_id:)
-        query = URI.encode_www_form(
+        body = {
           client_id: project_id,
           client_secret: WorkOS.key!,
           grant_type: 'authorization_code',
           code: code,
-        )
+        }
 
-        response = client.request(post_request(path: "/sso/token?#{query}"))
+        response = client.request(post_request(path: '/sso/token', body: body))
         check_and_raise_profile_error(response: response)
 
         WorkOS::Profile.new(response.body)

--- a/spec/lib/workos/sso_spec.rb
+++ b/spec/lib/workos/sso_spec.rb
@@ -127,7 +127,7 @@ describe WorkOS::SSO do
       }
     end
 
-    let(:query) do
+    let(:request_body) do
       {
         client_id: args[:project_id],
         client_secret: WorkOS.key,
@@ -137,29 +137,29 @@ describe WorkOS::SSO do
     end
     let(:user_agent) { 'user-agent-string' }
     let(:headers) { { 'User-Agent' => user_agent } }
+
     before do
       allow(described_class).to receive(:user_agent).and_return(user_agent)
     end
 
     context 'with a successful response' do
-      let(:body) { File.read("#{SPEC_ROOT}/support/profile.txt") }
+      let(:response_body) { File.read("#{SPEC_ROOT}/support/profile.txt") }
 
       before do
         stub_request(:post, 'https://api.workos.com/sso/token').
-          with(query: query, headers: headers).
-          to_return(status: 200, body: body)
+          with(headers: headers, body: request_body).
+          to_return(status: 200, body: response_body)
       end
 
       it 'includes the SDK Version header' do
         described_class.profile(**args)
 
         expect(a_request(:post, 'https://api.workos.com/sso/token').
-          with(query: query, headers: headers)).to have_been_made
+          with(headers: headers, body: request_body)).to have_been_made
       end
 
       it 'returns a WorkOS::Profile' do
         profile = described_class.profile(**args)
-
         expect(profile).to be_a(WorkOS::Profile)
       end
     end
@@ -167,7 +167,7 @@ describe WorkOS::SSO do
     context 'with an unprocessable request' do
       before do
         stub_request(:post, 'https://api.workos.com/sso/token').
-          with(query: query, headers: headers).
+          with(headers: headers, body: request_body).
           to_return(
             headers: { 'X-Request-ID' => 'request-id' },
             status: 422,
@@ -188,7 +188,7 @@ describe WorkOS::SSO do
     context 'with an expired code' do
       before do
         stub_request(:post, 'https://api.workos.com/sso/token').
-          with(query: query).
+          with(body: request_body).
           to_return(
             status: 201,
             headers: { 'X-Request-ID' => 'request-id' },


### PR DESCRIPTION
This changes the `profile` request to use the `POST` body instead of query parameters.