### PR TITLE
Update API Key Environment Variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 # vendor/Pods/
 
 ## Documentation cache and generated files:
+/bin/.yardoc/
 /.yardoc/
 /_yardoc/
 /doc/

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ gem 'workos'
 
 To use the SDK you must first provide your API key from the [WorkOS Developer Dashboard](https://dashboard.workos.com/api-keys).
 
-You can do this through the `WORKOS_KEY` environment variable or by calling `WorkOS.key = [your API key]`.
+You can do this through the `WORKOS_API_KEY` environment variable or by calling `WorkOS.key = [your API key]`.
 
-The WorkOS Gem will read the environment variable `WORKOS_KEY`:
+The WorkOS Gem will read the environment variable `WORKOS_API_KEY`:
 
 ```sh
-$ WORKOS_KEY=[your api key] ruby app.rb
+$ WORKOS_API_KEY=[your api key] ruby app.rb
 ```
 
 Alternatively, you may set the key yourself, such as in an initializer in your application load path:

--- a/docs/WorkOS.html
+++ b/docs/WorkOS.html
@@ -88,7 +88,7 @@
 <h2>Overview</h2><div class="docstring">
   <div class="discussion">
     
-<p>Use the WorkOS module to authenticate your requests to the WorkOS API. The gem will read your API key automatically from the ENV var `WORKOS_KEY`. Alternatively, you can set the key yourself with `WorkOS.key = [your api key]` somewhere in the load path of your application, such as an initializer.</p>
+<p>Use the WorkOS module to authenticate your requests to the WorkOS API. The gem will read your API key automatically from the ENV var `WORKOS_API_KEY`. Alternatively, you can set the key yourself with `WorkOS.key = [your api key]` somewhere in the load path of your application, such as an initializer.</p>
 
 
   </div>
@@ -314,7 +314,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Mar 19 20:24:36 2020 by
+  Generated on Tue Apr  7 16:45:04 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.22 (ruby-2.6.5).
 </div>

--- a/docs/WorkOS/APIError.html
+++ b/docs/WorkOS/APIError.html
@@ -150,7 +150,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Mar 19 20:24:37 2020 by
+  Generated on Tue Apr  7 16:45:04 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.22 (ruby-2.6.5).
 </div>

--- a/docs/WorkOS/AuditTrail.html
+++ b/docs/WorkOS/AuditTrail.html
@@ -225,7 +225,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Mar 19 20:24:37 2020 by
+  Generated on Tue Apr  7 16:45:04 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.22 (ruby-2.6.5).
 </div>

--- a/docs/WorkOS/AuthenticationError.html
+++ b/docs/WorkOS/AuthenticationError.html
@@ -150,7 +150,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Mar 19 20:24:37 2020 by
+  Generated on Tue Apr  7 16:45:04 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.22 (ruby-2.6.5).
 </div>

--- a/docs/WorkOS/Base.html
+++ b/docs/WorkOS/Base.html
@@ -277,7 +277,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Mar 19 20:24:36 2020 by
+  Generated on Tue Apr  7 16:45:04 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.22 (ruby-2.6.5).
 </div>

--- a/docs/WorkOS/Client.html
+++ b/docs/WorkOS/Client.html
@@ -494,7 +494,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Mar 19 20:24:37 2020 by
+  Generated on Tue Apr  7 16:45:04 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.22 (ruby-2.6.5).
 </div>

--- a/docs/WorkOS/InvalidRequestError.html
+++ b/docs/WorkOS/InvalidRequestError.html
@@ -150,7 +150,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Mar 19 20:24:37 2020 by
+  Generated on Tue Apr  7 16:45:04 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.22 (ruby-2.6.5).
 </div>

--- a/docs/WorkOS/Profile.html
+++ b/docs/WorkOS/Profile.html
@@ -778,7 +778,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Mar 19 20:24:37 2020 by
+  Generated on Tue Apr  7 16:45:04 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.22 (ruby-2.6.5).
 </div>

--- a/docs/WorkOS/SSO.html
+++ b/docs/WorkOS/SSO.html
@@ -681,7 +681,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Mar 19 20:24:36 2020 by
+  Generated on Tue Apr  7 16:45:04 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.22 (ruby-2.6.5).
 </div>

--- a/docs/WorkOS/Types.html
+++ b/docs/WorkOS/Types.html
@@ -118,7 +118,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Mar 19 20:24:36 2020 by
+  Generated on Tue Apr  7 16:45:04 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.22 (ruby-2.6.5).
 </div>

--- a/docs/WorkOS/Types/ProfileStruct.html
+++ b/docs/WorkOS/Types/ProfileStruct.html
@@ -125,7 +125,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Mar 19 20:24:37 2020 by
+  Generated on Tue Apr  7 16:45:04 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.22 (ruby-2.6.5).
 </div>

--- a/docs/WorkOS/Types/Provider.html
+++ b/docs/WorkOS/Types/Provider.html
@@ -125,7 +125,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Mar 19 20:24:37 2020 by
+  Generated on Tue Apr  7 16:45:04 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.22 (ruby-2.6.5).
 </div>

--- a/docs/WorkOS/WorkOSError.html
+++ b/docs/WorkOS/WorkOSError.html
@@ -437,7 +437,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Mar 19 20:24:37 2020 by
+  Generated on Tue Apr  7 16:45:04 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.22 (ruby-2.6.5).
 </div>

--- a/docs/file.README.html
+++ b/docs/file.README.html
@@ -84,11 +84,11 @@
 
 <p>To use the SDK you must first provide your API key from the <a href="https://dashboard.workos.com/api-keys">WorkOS Developer Dashboard</a>.</p>
 
-<p>You can do this through the <code>WORKOS_KEY</code> environment variable or by calling <code>WorkOS.key = [your API key]</code>.</p>
+<p>You can do this through the <code>WORKOS_API_KEY</code> environment variable or by calling <code>WorkOS.key = [your API key]</code>.</p>
 
-<p>The WorkOS Gem will read the environment variable <code>WORKOS_KEY</code>:</p>
+<p>The WorkOS Gem will read the environment variable <code>WORKOS_API_KEY</code>:</p>
 
-<pre class="code ruby"><code class="ruby">$ WORKOS_KEY=[your api key] ruby app.rb
+<pre class="code ruby"><code class="ruby">$ WORKOS_API_KEY=[your api key] ruby app.rb
 </code></pre>
 
 <p>Alternatively, you may set the key yourself, such as in an initializer in your application load path:</p>
@@ -242,7 +242,7 @@
 </div></div>
 
       <div id="footer">
-  Generated on Thu Mar 19 20:24:36 2020 by
+  Generated on Tue Apr  7 16:45:04 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.22 (ruby-2.6.5).
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -240,7 +240,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Mar 19 20:24:36 2020 by
+  Generated on Tue Apr  7 16:45:03 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.22 (ruby-2.6.5).
 </div>

--- a/docs/top-level-namespace.html
+++ b/docs/top-level-namespace.html
@@ -100,7 +100,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Mar 19 20:24:36 2020 by
+  Generated on Tue Apr  7 16:45:04 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.22 (ruby-2.6.5).
 </div>

--- a/lib/workos.rb
+++ b/lib/workos.rb
@@ -6,7 +6,7 @@ require 'sorbet-runtime'
 
 # Use the WorkOS module to authenticate your
 # requests to the WorkOS API. The gem will read
-# your API key automatically from the ENV var `WORKOS_KEY`.
+# your API key automatically from the ENV var `WORKOS_API_KEY`.
 # Alternatively, you can set the key yourself with
 # `WorkOS.key = [your api key]` somewhere in the load path of
 # your application, such as an initializer.
@@ -37,5 +37,5 @@ module WorkOS
   autoload :AuthenticationError, 'workos/errors'
   autoload :InvalidRequestError, 'workos/errors'
 
-  WorkOS.key = ENV['WORKOS_KEY'] unless ENV['WORKOS_KEY'].nil?
+  WorkOS.key = ENV['WORKOS_API_KEY'] unless ENV['WORKOS_API_KEY'].nil?
 end


### PR DESCRIPTION
This PR replaces the `WORKOS_KEY` environment variable with `WORKOS_API_KEY`.