### PR TITLE
Require 'net/http' from WorkOS::DirectorySync

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    workos (0.4.0)
+    workos (0.4.1)
       sorbet-runtime (~> 0.5)
 
 GEM
@@ -56,7 +56,7 @@ GEM
     simplecov-html (0.10.2)
     sorbet (0.5.5560)
       sorbet-static (= 0.5.5560)
-    sorbet-runtime (0.5.5858)
+    sorbet-runtime (0.5.5862)
     sorbet-static (0.5.5560-universal-darwin-14)
     unicode-display_width (1.6.0)
     url (0.3.2)

--- a/lib/workos/directory_sync.rb
+++ b/lib/workos/directory_sync.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 # typed: true
 
+require 'net/http'
+
 module WorkOS
   # The Directory Sync module provides convenience methods for working with the
   # WorkOS Directory Sync platform. You'll need a valid API key and to have

--- a/lib/workos/version.rb
+++ b/lib/workos/version.rb
@@ -2,5 +2,5 @@
 # typed: strong
 
 module WorkOS
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 end


### PR DESCRIPTION
* Encountered an issue in a simple example Sinatra app where calling
  `WorkOS::DirectorySync.list_directories` would encounter an issue
  with `Net` being an undefined constant. Adding this require resolves
  the issue.
* Bump gem to 0.4.1

```
NameError - uninitialized constant Net
Did you mean?  Set:
	/Users/willman/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/workos-0.4.0/lib/workos/client.rb:45:in `get_request'
```