### PR TITLE
Use require_all to pull in types folder

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     workos (0.7.0)
+      require_all (~> 3.0.0)
       sorbet-runtime (~> 0.5)
 
 GEM
@@ -26,6 +27,7 @@ GEM
     public_suffix (4.0.2)
     rainbow (3.0.0)
     rake (13.0.1)
+    require_all (3.0.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -54,7 +56,7 @@ GEM
     simplecov-html (0.12.2)
     sorbet (0.5.5560)
       sorbet-static (= 0.5.5560)
-    sorbet-runtime (0.5.5909)
+    sorbet-runtime (0.5.5923)
     sorbet-static (0.5.5560-universal-darwin-14)
     unicode-display_width (1.6.0)
     vcr (5.0.0)

--- a/lib/workos/types.rb
+++ b/lib/workos/types.rb
@@ -1,16 +1,11 @@
 # frozen_string_literal: true
-# typed: strong
+
+require 'require_all'
 
 module WorkOS
   # WorkOS believes strongly in typed languages,
   # so we're using Sorbet throughout this Ruby gem.
   module Types
-    require_relative 'types/connection_struct'
-    require_relative 'types/intent_enum'
-    require_relative 'types/list_struct'
-    require_relative 'types/organization_struct'
-    require_relative 'types/passwordless_session_struct'
-    require_relative 'types/profile_struct'
-    require_relative 'types/provider_enum'
+    require_all 'lib/workos/types'
   end
 end

--- a/workos.gemspec
+++ b/workos.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'require_all', '~> 3.0.0'
   spec.add_dependency 'sorbet-runtime', '~> 0.5'
 
   spec.add_development_dependency 'bundler', '>= 2.0.1'


### PR DESCRIPTION
* Resolves a hidden step needed before adding a file to the types
  folder that can be confusing for developers new to the SDK
  codebase.
* Discussion here: https://github.com/workos-inc/workos-ruby/pull/48#discussion_r485866330