### PR TITLE
Add missing option `occurred_at_lte`

### DIFF
--- a/lib/workos/audit_trail.rb
+++ b/lib/workos/audit_trail.rb
@@ -83,8 +83,8 @@ module WorkOS
       #  event occurred at or after
       # @option options [String] occurred_at_lt ISO-8601 datetime of when an
       #  event occurred before
-      # @option options [String] occurred_at_lte ISO-8601 datetime of when an event occured at
-      #  or before
+      # @option options [String] occurred_at_lte ISO-8601 datetime of when an
+      #  event occured at or before
       # @option options [String] search Keyword search
       #
       # @return [Array<Hash>]

--- a/lib/workos/audit_trail.rb
+++ b/lib/workos/audit_trail.rb
@@ -83,7 +83,7 @@ module WorkOS
       #  event occurred at or after
       # @option options [String] occurred_at_lt ISO-8601 datetime of when an
       #  event occurred before
-      # @option options [String] ISO-8601 datetime of when an event occured at
+      # @option options [String] occurred_at_lte ISO-8601 datetime of when an event occured at
       #  or before
       # @option options [String] search Keyword search
       #


### PR DESCRIPTION
This PR lists the `occurred_at_lte` option for the `get_events` method.