### PR TITLE
Add MagicLink support through Passwordless module

### DIFF
--- a/lib/workos.rb
+++ b/lib/workos.rb
@@ -32,6 +32,7 @@ module WorkOS
   autoload :Connection, 'workos/connection'
   autoload :DirectorySync, 'workos/directory_sync'
   autoload :Organization, 'workos/organization'
+  autoload :Passwordless, 'workos/passwordless'
   autoload :Portal, 'workos/portal'
   autoload :Profile, 'workos/profile'
   autoload :SSO, 'workos/sso'

--- a/lib/workos/client.rb
+++ b/lib/workos/client.rb
@@ -109,8 +109,8 @@ module WorkOS
         )
       when 422
         errors = nil
-        if json['errors']
-          errors = json['errors'].map do |error|
+        errors = if json['errors']
+          json['errors'].map do |error|
             "#{error['field']}: #{error['code']}"
           end.join('; ')
         end

--- a/lib/workos/client.rb
+++ b/lib/workos/client.rb
@@ -81,12 +81,6 @@ module WorkOS
       ].join('; ')
     end
 
-    def extract_error(errors)
-      errors.map do |error|
-        "#{error['field']}: #{error['code']}"
-      end.join('; ')
-    end
-
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
     sig { params(response: ::T.untyped).void }
     def handle_error_response(response:)
@@ -125,5 +119,13 @@ module WorkOS
       end
     end
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
+
+    private
+
+    def extract_error(errors)
+      errors.map do |error|
+        "#{error['field']}: #{error['code']}"
+      end.join('; ')
+    end
   end
 end

--- a/lib/workos/client.rb
+++ b/lib/workos/client.rb
@@ -115,7 +115,7 @@ module WorkOS
           end.join('; ')
         end
 
-        message = "#{json['message']}"
+        message = json['message']
         message += " (#{errors})" if errors
         raise InvalidRequestError.new(
           message: message,

--- a/lib/workos/client.rb
+++ b/lib/workos/client.rb
@@ -108,11 +108,15 @@ module WorkOS
           request_id: response['x-request-id'],
         )
       when 422
-        errors = json['errors'].map do |error|
-          "#{error['field']}: #{error['code']}"
-        end.join('; ')
+        errors = nil
+        if json['errors']
+          errors = json['errors'].map do |error|
+            "#{error['field']}: #{error['code']}"
+          end.join('; ')
+        end
 
-        message = "#{json['message']} (#{errors})"
+        message = "#{json['message']}"
+        message += " (#{errors})" if errors
         raise InvalidRequestError.new(
           message: message,
           http_status: http_status,

--- a/lib/workos/client.rb
+++ b/lib/workos/client.rb
@@ -81,8 +81,13 @@ module WorkOS
       ].join('; ')
     end
 
+    def extract_error(errors)
+      errors.map do |error|
+        "#{error['field']}: #{error['code']}"
+      end.join('; ')
+    end
 
-    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
     sig { params(response: ::T.untyped).void }
     def handle_error_response(response:)
       http_status = response.code.to_i
@@ -108,15 +113,10 @@ module WorkOS
           request_id: response['x-request-id'],
         )
       when 422
-        errors = nil
-        errors = if json['errors']
-          json['errors'].map do |error|
-            "#{error['field']}: #{error['code']}"
-          end.join('; ')
-        end
-
         message = json['message']
+        errors = extract_error(json['errors']) if json['errors']
         message += " (#{errors})" if errors
+
         raise InvalidRequestError.new(
           message: message,
           http_status: http_status,
@@ -124,6 +124,6 @@ module WorkOS
         )
       end
     end
-    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
   end
 end

--- a/lib/workos/passwordless.rb
+++ b/lib/workos/passwordless.rb
@@ -33,25 +33,27 @@ module WorkOS
         ).returns(WorkOS::Types::PasswordlessSessionStruct)
       end
 
+      # rubocop:disable Metrics/MethodLength
       def create_session(options)
         response = execute_request(
           request: post_request(
             path: '/passwordless/sessions',
             auth: true,
             body: options,
-          )
+          ),
         )
 
         hash = JSON.parse(response.body)
 
         WorkOS::Types::PasswordlessSessionStruct.new(
-          id: hash["id"],
-          email: hash["email"],
-          expires_at: Date.parse(hash["expires_at"]),
-          link: hash["link"],
-          object: hash["object"],
+          id: hash['id'],
+          email: hash['email'],
+          expires_at: Date.parse(hash['expires_at']),
+          link: hash['link'],
+          object: hash['object'],
         )
       end
+      # rubocop:enable Metrics/MethodLength
 
       # Send a Passwordless Session via email.
       #

--- a/lib/workos/passwordless.rb
+++ b/lib/workos/passwordless.rb
@@ -31,17 +31,27 @@ module WorkOS
       sig do
         params(
           options: Hash,
-        ).returns(::T.untyped)
+        ).returns(WorkOS::Types::PasswordlessSessionStruct)
       end
 
       def create_session(options)
-        request = post_request(
-          path: '/passwordless/sessions',
-          auth: true,
-          body: options,
+        response = execute_request(
+          request: post_request(
+            path: '/passwordless/sessions',
+            auth: true,
+            body: options,
+          )
         )
 
-        execute_request(request: request)
+        hash = JSON.parse(response.body)
+
+        WorkOS::Types::PasswordlessSessionStruct.new(
+          id: hash["id"],
+          email: hash["email"],
+          expires_at: Date.parse(hash["expires_at"]),
+          link: hash["link"],
+          object: hash["object"],
+        )
       end
 
       # Send a Passwordless Session via email.

--- a/lib/workos/passwordless.rb
+++ b/lib/workos/passwordless.rb
@@ -2,7 +2,6 @@
 # typed: true
 
 require 'net/http'
-require 'uri'
 
 module WorkOS
   # The Passwordless module provides convenience methods for working with

--- a/lib/workos/passwordless.rb
+++ b/lib/workos/passwordless.rb
@@ -50,7 +50,6 @@ module WorkOS
           email: hash['email'],
           expires_at: Date.parse(hash['expires_at']),
           link: hash['link'],
-          object: hash['object'],
         )
       end
       # rubocop:enable Metrics/MethodLength

--- a/lib/workos/passwordless.rb
+++ b/lib/workos/passwordless.rb
@@ -16,7 +16,7 @@ module WorkOS
       include Base
       include Client
 
-      # Create an Passwordless Session.
+      # Create a Passwordless Session.
       #
       # @param [Hash] options A hash with options for the session
       # @option options [String] email The email of the user to authenticate.

--- a/lib/workos/passwordless.rb
+++ b/lib/workos/passwordless.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+# typed: true
+
+require 'net/http'
+require 'uri'
+
+module WorkOS
+  # The Passwordless module provides convenience methods for working with
+  # passwordless sessions including the WorkOS Magic Link. You'll need a valid API key.
+  #
+  # @see https://workos.com/docs/sso/configuring-magic-link
+  module Passwordless
+    class << self
+      extend T::Sig
+      include Base
+      include Client
+
+      # Create an Passwordless Session.
+      #
+      # @param [Hash] options A hash with options for the session
+      # @option options [String] email The email of the user to authenticate.
+      # @option options [String] state Optional parameter that the redirect URI
+      #  received from WorkOS will contain. The state parameter can be used to
+      #  encode arbitrary information to help restore application state between
+      #  redirects.
+      # @option options [String] type The type of Passwordless Session to create.
+      #  Currently, the only supported value is 'MagicLink'.
+      #
+      # @return Hash
+      sig do
+        params(
+          options: Hash,
+        ).returns(::T.untyped)
+      end
+
+      def create_session(options)
+        request = post_request(
+          path: '/passwordless/sessions',
+          auth: true,
+          body: options,
+        )
+
+        execute_request(request: request)
+      end
+
+      # Send a Passwordless Session via email.
+      #
+      # @param [String] session_id The unique identifier of the Passwordless
+      #  Session to send an email for.
+      #
+      # @return Hash
+      sig do
+        params(
+          session_id: String
+        ).returns(T::Hash[String, T::Boolean])
+      end
+
+      def send_session(session_id)
+        response = execute_request(
+          request: post_request(
+            path: "/passwordless/sessions/#{session_id}/send",
+            auth: true,
+          ),
+        )
+
+        JSON.parse(response.body)
+      end
+    end
+  end
+end

--- a/lib/workos/passwordless.rb
+++ b/lib/workos/passwordless.rb
@@ -6,7 +6,8 @@ require 'uri'
 
 module WorkOS
   # The Passwordless module provides convenience methods for working with
-  # passwordless sessions including the WorkOS Magic Link. You'll need a valid API key.
+  # passwordless sessions including the WorkOS Magic Link. You'll need a valid
+  # API key.
   #
   # @see https://workos.com/docs/sso/configuring-magic-link
   module Passwordless
@@ -23,8 +24,8 @@ module WorkOS
       #  received from WorkOS will contain. The state parameter can be used to
       #  encode arbitrary information to help restore application state between
       #  redirects.
-      # @option options [String] type The type of Passwordless Session to create.
-      #  Currently, the only supported value is 'MagicLink'.
+      # @option options [String] type The type of Passwordless Session to
+      #  create. Currently, the only supported value is 'MagicLink'.
       #
       # @return Hash
       sig do
@@ -51,7 +52,7 @@ module WorkOS
       # @return Hash
       sig do
         params(
-          session_id: String
+          session_id: String,
         ).returns(T::Hash[String, T::Boolean])
       end
 

--- a/lib/workos/types.rb
+++ b/lib/workos/types.rb
@@ -9,6 +9,7 @@ module WorkOS
     require_relative 'types/intent_enum'
     require_relative 'types/list_struct'
     require_relative 'types/organization_struct'
+    require_relative 'types/passwordless_session_struct'
     require_relative 'types/profile_struct'
     require_relative 'types/provider_enum'
   end

--- a/lib/workos/types/passwordless_session_struct.rb
+++ b/lib/workos/types/passwordless_session_struct.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+# typed: strict
+
+module WorkOS
+  module Types
+    # This PasswordlessSessionStruct acts as a typed interface
+    # for the Passwordless class
+    class PasswordlessSessionStruct < T::Struct
+      const :id, String
+      const :email, String
+      const :expires_at, Date
+      const :link, String
+      const :object, String
+    end
+  end
+end

--- a/lib/workos/types/passwordless_session_struct.rb
+++ b/lib/workos/types/passwordless_session_struct.rb
@@ -10,7 +10,6 @@ module WorkOS
       const :email, String
       const :expires_at, Date
       const :link, String
-      const :object, String
     end
   end
 end

--- a/spec/lib/workos/passwordless_spec.rb
+++ b/spec/lib/workos/passwordless_spec.rb
@@ -23,9 +23,7 @@ describe WorkOS::Passwordless do
         VCR.use_cassette('passwordless/create_session') do
           response = described_class.create_session(valid_options)
 
-          expect(response.code).to eq '201'
-          json = JSON.parse(response.body)
-          expect(json['email']).to eq 'demo@workos-okta.com'
+          expect(response.email).to eq 'demo@workos-okta.com'
         end
       end
     end

--- a/spec/lib/workos/passwordless_spec.rb
+++ b/spec/lib/workos/passwordless_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+# typed: false
+
+describe WorkOS::Passwordless do
+  before(:all) do
+    WorkOS.key = 'key'
+  end
+
+  after(:all) do
+    WorkOS.key = nil
+  end
+
+  describe '.create_session' do
+    context 'with valid options payload' do
+      let(:valid_options) do
+        {
+          email: 'demo@workos-okta.com',
+          type: 'MagicLink',
+        }
+      end
+
+      it 'creates a session' do
+        VCR.use_cassette('passwordless/create_session') do
+          response = described_class.create_session(valid_options)
+
+          expect(response.code).to eq '201'
+          json = JSON.parse(response.body)
+          expect(json['email']).to eq 'demo@workos-okta.com'
+        end
+      end
+    end
+
+    context 'with invalid event payload' do
+      let(:invalid_options) do
+        {}
+      end
+
+      it 'raises an error' do
+        VCR.use_cassette('passwordless/create_session_invalid') do
+          expect do
+            described_class.create_session(invalid_options)
+          end.to raise_error(
+            WorkOS::InvalidRequestError,
+            /Status 422, Validation failed \(email: email must be a string; type: type must be a valid enum value\)/,
+          )
+        end
+      end
+    end
+  end
+
+  describe '.send_session' do
+    context 'with valid session id' do
+      let(:valid_options) do
+        {
+          email: 'demo@workos-okta.com',
+          type: 'MagicLink',
+        }
+      end
+
+      it 'send a session' do
+
+        VCR.use_cassette('passwordless/send_session') do
+          response = described_class.send_session('passwordless_session_01EJC0F4KH42T11Y2DHPEB09BM')
+
+          expect(response['success']).to eq true
+        end
+      end
+    end
+
+    context 'with invalid session id' do
+      it 'raises an error' do
+        VCR.use_cassette('passwordless/send_session_invalid') do
+          expect do
+            described_class.send_session('session_123')
+          end.to raise_error(
+            WorkOS::InvalidRequestError,
+            /Status 422, The passwordless session 'session_123' has expired or is invalid./,
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/workos/passwordless_spec.rb
+++ b/spec/lib/workos/passwordless_spec.rb
@@ -58,9 +58,10 @@ describe WorkOS::Passwordless do
       end
 
       it 'send a session' do
-
         VCR.use_cassette('passwordless/send_session') do
-          response = described_class.send_session('passwordless_session_01EJC0F4KH42T11Y2DHPEB09BM')
+          response = described_class.send_session(
+            'passwordless_session_01EJC0F4KH42T11Y2DHPEB09BM',
+          )
 
           expect(response['success']).to eq true
         end

--- a/spec/support/fixtures/vcr_cassettes/passwordless/create_session.yml
+++ b/spec/support/fixtures/vcr_cassettes/passwordless/create_session.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.workos.com/passwordless/sessions
+    body:
+      encoding: UTF-8
+      string: '{"email":"demo@workos-okta.com","type":"MagicLink"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - WorkOS; ruby/2.7.1; x86_64-darwin19; v0.7.0
+      Authorization:
+      - Bearer <API_KEY>
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin, Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Content-Security-Policy:
+      - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
+        https: data:;frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src
+        ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+      X-Dns-Prefetch-Control:
+      - 'off'
+      Expect-Ct:
+      - max-age=0
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      X-Download-Options:
+      - noopen
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - no-referrer
+      X-Xss-Protection:
+      - '0'
+      X-Request-Id:
+      - 611c2a85-84e1-4bad-a2ec-43cf8371f134
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '238'
+      Etag:
+      - W/"ee-6KkIusxSXraxKqTLP+31C0PeHDU"
+      Date:
+      - Wed, 16 Sep 2020 15:39:08 GMT
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"passwordless_session","id":"passwordless_session_01EJBS3JSXFE2DP6JC6ZVBZ095","email":"demo@workos-okta.com","expires_at":"2020-09-16T15:44:08.475Z","link":"https://api.workos.com/passwordless/ZBxkn2ZTUYqa82ky6QEYecemI/confirm"}'
+    http_version:
+  recorded_at: Wed, 16 Sep 2020 15:39:08 GMT
+recorded_with: VCR 5.0.0

--- a/spec/support/fixtures/vcr_cassettes/passwordless/create_session_invalid.yml
+++ b/spec/support/fixtures/vcr_cassettes/passwordless/create_session_invalid.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.workos.com/passwordless/sessions
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - WorkOS; ruby/2.7.1; x86_64-darwin19; v0.7.0
+      Authorization:
+      - Bearer sk_4q5ka3d9bx0XJiZhkKmUIOG87
+  response:
+    status:
+      code: 422
+      message: Unprocessable Entity
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin, Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Content-Security-Policy:
+      - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
+        https: data:;frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src
+        ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+      X-Dns-Prefetch-Control:
+      - 'off'
+      Expect-Ct:
+      - max-age=0
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      X-Download-Options:
+      - noopen
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - no-referrer
+      X-Xss-Protection:
+      - '0'
+      X-Request-Id:
+      - e3ca7215-2b2d-45cf-a04f-90279225f27e
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '150'
+      Etag:
+      - W/"96-O5ltHaJ3rEQ8+dqFwhN+Lhmgdb0"
+      Date:
+      - Wed, 16 Sep 2020 17:34:07 GMT
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"message":"Validation failed","errors":[{"field":"email","code":"email
+        must be a string"},{"field":"type","code":"type must be a valid enum value"}]}'
+    http_version: 
+  recorded_at: Wed, 16 Sep 2020 17:34:07 GMT
+recorded_with: VCR 5.0.0

--- a/spec/support/fixtures/vcr_cassettes/passwordless/send_session.yml
+++ b/spec/support/fixtures/vcr_cassettes/passwordless/send_session.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.workos.com/passwordless/sessions/passwordless_session_01EJC0F4KH42T11Y2DHPEB09BM/send
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - WorkOS; ruby/2.7.1; x86_64-darwin19; v0.7.0
+      Authorization:
+      - Bearer sk_4q5ka3d9bx0XJiZhkKmUIOG87
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin, Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Content-Security-Policy:
+      - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
+        https: data:;frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src
+        ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+      X-Dns-Prefetch-Control:
+      - 'off'
+      Expect-Ct:
+      - max-age=0
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      X-Download-Options:
+      - noopen
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - no-referrer
+      X-Xss-Protection:
+      - '0'
+      X-Request-Id:
+      - d7d72520-9223-4145-b34e-df5e80a776d6
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '16'
+      Etag:
+      - W/"10-oV4hJxRVSENxc/wX8+mA4/Pe4tA"
+      Date:
+      - Wed, 16 Sep 2020 17:47:47 GMT
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"success":true}'
+    http_version:
+  recorded_at: Wed, 16 Sep 2020 17:47:47 GMT
+recorded_with: VCR 5.0.0

--- a/spec/support/fixtures/vcr_cassettes/passwordless/send_session_invalid.yml
+++ b/spec/support/fixtures/vcr_cassettes/passwordless/send_session_invalid.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.workos.com/passwordless/sessions/session_123/send
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - WorkOS; ruby/2.7.1; x86_64-darwin19; v0.7.0
+      Authorization:
+      - Bearer sk_4q5ka3d9bx0XJiZhkKmUIOG87
+  response:
+    status:
+      code: 422
+      message: Unprocessable Entity
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin, Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Content-Security-Policy:
+      - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
+        https: data:;frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src
+        ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+      X-Dns-Prefetch-Control:
+      - 'off'
+      Expect-Ct:
+      - max-age=0
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      X-Download-Options:
+      - noopen
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - no-referrer
+      X-Xss-Protection:
+      - '0'
+      X-Request-Id:
+      - 6c22578f-9d49-4118-a7bd-18014d447aad
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '79'
+      Etag:
+      - W/"4f-NjqaLicbRDM9SfS5gYKHlSgozt0"
+      Date:
+      - Wed, 16 Sep 2020 17:52:24 GMT
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"message":"The passwordless session ''session_123'' has expired or
+        is invalid."}'
+    http_version: 
+  recorded_at: Wed, 16 Sep 2020 17:52:24 GMT
+recorded_with: VCR 5.0.0


### PR DESCRIPTION
Add Passwordless support for MagicLink. Adds two methods
 - `create_session` - generate a passwordless session for a user from their email
 - `send_session` - send an email to a user with a Magic Link confirmation URL