### PR TITLE
Return a collection of WorkOS::Organization from list_organizations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    workos (0.7.0)
+    workos (0.8.0)
       require_all (~> 3.0.0)
       sorbet-runtime (~> 0.5)
 

--- a/lib/workos/portal.rb
+++ b/lib/workos/portal.rb
@@ -103,8 +103,12 @@ module WorkOS
 
         parsed_response = JSON.parse(response.body)
 
+        organizations = parsed_response['data'].map do |organization|
+          ::WorkOS::Organization.new(organization.to_json)
+        end
+
         WorkOS::Types::ListStruct.new(
-          data: parsed_response['data'],
+          data: organizations,
           list_metadata: parsed_response['listMetadata'],
         )
       end

--- a/lib/workos/version.rb
+++ b/lib/workos/version.rb
@@ -2,5 +2,5 @@
 # typed: strong
 
 module WorkOS
-  VERSION = '0.7.0'
+  VERSION = '0.8.0'
 end


### PR DESCRIPTION
* An issue in our earlier implementation was returning the raw
  response without wrapping it in our helper object. This commit makes
  the breaking change to now return the WorkOS::Organization instance
  automatically.
* Bump to 0.8.0