### PR TITLE
Feature/ch4085/add redirect uri passwordless session option

### DIFF
--- a/lib/workos/passwordless.rb
+++ b/lib/workos/passwordless.rb
@@ -25,6 +25,9 @@ module WorkOS
       #  redirects.
       # @option options [String] type The type of Passwordless Session to
       #  create. Currently, the only supported value is 'MagicLink'.
+      # @option options [String] redirect_uri The URI where users are directed
+      #  after completing the authentication step. Must match a
+      #  configured redirect URI on your WorkOS dashboard.
       #
       # @return Hash
       sig do

--- a/spec/lib/workos/passwordless_spec.rb
+++ b/spec/lib/workos/passwordless_spec.rb
@@ -16,7 +16,7 @@ describe WorkOS::Passwordless do
         {
           email: 'demo@workos-okta.com',
           type: 'MagicLink',
-          redirect_uri: 'foo.com/auth/callback'
+          redirect_uri: 'foo.com/auth/callback',
         }
       end
 

--- a/spec/lib/workos/passwordless_spec.rb
+++ b/spec/lib/workos/passwordless_spec.rb
@@ -16,6 +16,7 @@ describe WorkOS::Passwordless do
         {
           email: 'demo@workos-okta.com',
           type: 'MagicLink',
+          redirect_uri: 'foo.com/auth/callback'
         }
       end
 


### PR DESCRIPTION
Add Redirect URI in comment options list for the passwordless module, and in the tests. Also added a description of implementing Magic Link in the README.

It seems like a lot of the README is duplicated from the docs we already have. Maybe it's better to link to those docs as the single source of truth, rather than duplicating them in the README?