### PR TITLE
Bump SDK minor version to 0.9.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    workos (0.9.0)
+    workos (0.9.1)
       sorbet-runtime (~> 0.5)
 
 GEM

--- a/lib/workos/version.rb
+++ b/lib/workos/version.rb
@@ -2,5 +2,5 @@
 # typed: strong
 
 module WorkOS
-  VERSION = '0.9.0'
+  VERSION = '0.9.1'
 end


### PR DESCRIPTION
Increasing the SDK minor version to include my recent updates to the tests and docs. This highlights the support for the `redirect_uri` in the passwordless auth API endpoint.