### PR TITLE
Authenticate POST /events endpoint

### DIFF
--- a/lib/workos/audit_trail.rb
+++ b/lib/workos/audit_trail.rb
@@ -51,6 +51,7 @@ module WorkOS
       def create_event(event:, idempotency_key: nil)
         request = post_request(
           path: '/events',
+          auth: true,
           idempotency_key: idempotency_key,
           body: event,
         )


### PR DESCRIPTION
Before this change, I received 401 responses.
After this change, the request was a success.

Example program:

```ruby
require 'date'
require 'json'
require 'workos'

WorkOS.key = ENV.fetch('WORKOS_API_KEY')

event = {
  action_type: 'r',
  action: 'user.login_succeeded',
  actor_id: 'user_01DEQWZNQT8Y47HDPSJKQS1J3F',
  actor_name: 'WorkOS Ruby Gem Test',
  group: 'foo-corp.com',
  latitude: '40.676300',
  longitude: '-73.949200',
  location: '65.215.8.114',
  occurred_at: DateTime.now.iso8601,
  target_id: 'user_01DEQWZNQT8Y47HDPSJKQS1J3F',
  target_name: 'WorkOS Ruby Gem Test'
}

WorkOS::AuditTrail.create_event(event: event)
```