### PR TITLE
Bump SDK minor version to 0.9.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    workos (0.9.1)
+    workos (0.9.2)
       sorbet-runtime (~> 0.5)
 
 GEM
@@ -54,7 +54,7 @@ GEM
     simplecov-html (0.12.2)
     sorbet (0.5.5560)
       sorbet-static (= 0.5.5560)
-    sorbet-runtime (0.5.5943)
+    sorbet-runtime (0.5.6140)
     sorbet-static (0.5.5560-universal-darwin-14)
     unicode-display_width (1.6.0)
     vcr (5.0.0)

--- a/lib/workos/version.rb
+++ b/lib/workos/version.rb
@@ -2,5 +2,5 @@
 # typed: strong
 
 module WorkOS
-  VERSION = '0.9.1'
+  VERSION = '0.9.2'
 end


### PR DESCRIPTION
New release with:
- Audit Trail POST /events bug fix
- Require JSON gem for entire WorkOS module