### PR TITLE
Add blocks of code setting WorkOS.key per test

### DIFF
--- a/spec/lib/workos/audit_trail_spec.rb
+++ b/spec/lib/workos/audit_trail_spec.rb
@@ -2,14 +2,6 @@
 # typed: false
 
 describe WorkOS::AuditTrail do
-  before(:all) do
-    WorkOS.key = 'key'
-  end
-
-  after(:all) do
-    WorkOS.key = nil
-  end
-
   describe '.create_event' do
     context 'with valid event payload' do
       let(:valid_event) do

--- a/spec/lib/workos/directory_sync_spec.rb
+++ b/spec/lib/workos/directory_sync_spec.rb
@@ -2,14 +2,6 @@
 # typed: false
 
 describe WorkOS::DirectorySync do
-  before(:all) do
-    WorkOS.key = 'key'
-  end
-
-  after(:all) do
-    WorkOS.key = nil
-  end
-
   describe '.list_directories' do
     context 'with no options' do
       it 'returns directories' do

--- a/spec/lib/workos/passwordless_spec.rb
+++ b/spec/lib/workos/passwordless_spec.rb
@@ -2,14 +2,6 @@
 # typed: false
 
 describe WorkOS::Passwordless do
-  before(:all) do
-    WorkOS.key = 'key'
-  end
-
-  after(:all) do
-    WorkOS.key = nil
-  end
-
   describe '.create_session' do
     context 'with valid options payload' do
       let(:valid_options) do

--- a/spec/lib/workos/portal_spec.rb
+++ b/spec/lib/workos/portal_spec.rb
@@ -2,14 +2,6 @@
 # typed: false
 
 describe WorkOS::Portal do
-  before :all do
-    WorkOS.key = 'test'
-  end
-
-  after :all do
-    WorkOS.key = nil
-  end
-
   describe '.create_organization' do
     context 'with valid payload' do
       it 'creates an organization' do

--- a/spec/lib/workos/sso_spec.rb
+++ b/spec/lib/workos/sso_spec.rb
@@ -159,10 +159,6 @@ describe WorkOS::SSO do
   end
 
   describe '.profile' do
-    before do
-      WorkOS.key = 'api-key'
-    end
-
     let(:args) do
       {
         code: SecureRandom.hex(10),
@@ -274,14 +270,6 @@ describe WorkOS::SSO do
   end
 
   describe '.create_connection' do
-    before(:all) do
-      WorkOS.key = 'key'
-    end
-
-    after(:all) do
-      WorkOS.key = nil
-    end
-
     context 'with a valid source' do
       it 'creates a connection' do
         VCR.use_cassette('sso/create_connection_with_valid_source') do
@@ -312,14 +300,6 @@ describe WorkOS::SSO do
   end
 
   describe '.promote_draft_connection' do
-    before(:all) do
-      WorkOS.key = 'key'
-    end
-
-    after(:all) do
-      WorkOS.key = nil
-    end
-
     let(:token) { 'draft_conn_id' }
     let(:client_id) { 'proj_0239u590h' }
 
@@ -357,14 +337,6 @@ describe WorkOS::SSO do
   end
 
   describe '.list_connections' do
-    before(:all) do
-      WorkOS.key = 'key'
-    end
-
-    after(:all) do
-      WorkOS.key = nil
-    end
-
     context 'with no options' do
       it 'returns connections' do
         VCR.use_cassette('sso/list_connections') do
@@ -446,14 +418,6 @@ describe WorkOS::SSO do
   end
 
   describe '.get_connection' do
-    before(:all) do
-      WorkOS.key = 'key'
-    end
-
-    after(:all) do
-      WorkOS.key = nil
-    end
-
     context 'with a valid id' do
       it 'gets the connection details' do
         VCR.use_cassette('sso/get_connection_with_valid_id') do
@@ -484,14 +448,6 @@ describe WorkOS::SSO do
   end
 
   describe '.delete_connection' do
-    before(:all) do
-      WorkOS.key = 'key'
-    end
-
-    after(:all) do
-      WorkOS.key = nil
-    end
-
     context 'with a valid id' do
       it 'returns true' do
         VCR.use_cassette('sso/delete_connection_with_valid_id') do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,5 +48,6 @@ RSpec.configure do |config|
     end
   end)
 
+  config.before(:all) { WorkOS.key ||= '' }
   config.before(:each) { VCR.turn_on! }
 end


### PR DESCRIPTION
* The majority of the time our test suite does not need to make live
  requests against the API. We want to avoid this step where we set
  API keys in setup blocks to make requests. If you need to make a
  request (for example, setting up a new VCR cassette) run:
  WORKOS_API_KEY=<key> rspec