### PR TITLE
Remove support for deprecated `project_id` parameter

### DIFF
--- a/lib/workos/sso.rb
+++ b/lib/workos/sso.rb
@@ -30,8 +30,6 @@ module WorkOS
       #  WorkOS.
       # @param [String] client_id The WorkOS client ID for the environment
       #  where you've configured your SSO connection.
-      # @param [String] project_id The WorkOS project ID for the project.
-      # The project_id is deprecated in Dashboard2.
       # @param [String] redirect_uri The URI where users are directed
       #  after completing the authentication step. Must match a
       #  configured redirect URI on your WorkOS dashboard.
@@ -56,7 +54,6 @@ module WorkOS
       sig do
         params(
           redirect_uri: String,
-          project_id: T.nilable(String),
           client_id: T.nilable(String),
           domain: T.nilable(String),
           provider: T.nilable(String),
@@ -67,19 +64,12 @@ module WorkOS
       # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
       def authorization_url(
         redirect_uri:,
-        project_id: nil,
         client_id: nil,
         domain: nil,
         provider: nil,
         connection: nil,
         state: ''
       )
-        if project_id
-          warn '[DEPRECATION] `project_id` is deprecated.
-          Please use `client_id` instead.'
-          client_id = project_id
-        end
-
         validate_authorization_url_arguments(
           provider: provider,
           domain: domain,
@@ -104,9 +94,7 @@ module WorkOS
       #
       # @param [String] code The authorization code provided in the callback URL
       # @param [String] client_id The WorkOS client ID for the environment
-      #  where you've  configured your SSO connection
-      # @param [String] project_id The WorkOS project ID for the project.
-      # The project_id is deprecated in Dashboard2.
+      #  where you've configured your SSO connection
       #
       # @example
       #   WorkOS::SSO.profile(
@@ -127,17 +115,10 @@ module WorkOS
       sig do
         params(
           code: String,
-          project_id: T.nilable(String),
           client_id: T.nilable(String),
         ).returns(WorkOS::Profile)
       end
-      def profile(code:, project_id: nil, client_id: nil)
-        if project_id
-          warn '[DEPRECATION] `project_id` is deprecated.
-          Please use `client_id` instead.'
-          client_id = project_id
-        end
-
+      def profile(code:, client_id: nil)
         body = {
           client_id: client_id,
           client_secret: WorkOS.key!,

--- a/lib/workos/sso.rb
+++ b/lib/workos/sso.rb
@@ -61,7 +61,6 @@ module WorkOS
           state: T.nilable(String),
         ).returns(String)
       end
-      # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
       def authorization_url(
         redirect_uri:,
         client_id: nil,
@@ -88,7 +87,6 @@ module WorkOS
 
         "https://#{WorkOS::API_HOSTNAME}/sso/authorize?#{query}"
       end
-      # rubocop:enable Metrics/MethodLength, Metrics/ParameterLists
 
       # Fetch the profile details for the authenticated SSO user.
       #

--- a/spec/lib/workos/sso_spec.rb
+++ b/spec/lib/workos/sso_spec.rb
@@ -147,49 +147,6 @@ describe WorkOS::SSO do
         )
       end
     end
-
-    context 'passing the project_id' do
-      let(:args) do
-        {
-          domain: 'foo.com',
-          project_id: 'workos-proj-123',
-          redirect_uri: 'foo.com/auth/callback',
-          state: {
-            next_page: '/dashboard/edit',
-          }.to_s,
-        }
-      end
-      it 'raises a deprecation warning' do
-        expect do
-          described_class.authorization_url(**args)
-        end.to output(
-          "[DEPRECATION] `project_id` is deprecated.
-          Please use `client_id` instead.\n",
-        ).to_stderr
-      end
-
-      it 'returns a valid URL' do
-        authorization_url = described_class.authorization_url(**args)
-
-        expect(URI.parse(authorization_url)).to be_a URI
-      end
-
-      it 'returns the expected hostname' do
-        authorization_url = described_class.authorization_url(**args)
-
-        expect(URI.parse(authorization_url).host).to eq(WorkOS::API_HOSTNAME)
-      end
-
-      it 'returns the expected query string' do
-        authorization_url = described_class.authorization_url(**args)
-
-        expect(URI.parse(authorization_url).query).to eq(
-          'client_id=workos-proj-123&redirect_uri=foo.com%2Fauth%2Fcallback' \
-          '&response_type=code&state=%7B%3Anext_page%3D%3E%22%2Fdashboard%2F' \
-          'edit%22%7D&domain=foo.com',
-        )
-      end
-    end
   end
 
   describe '.profile' do


### PR DESCRIPTION
This PR removes support for the deprecated `project_id` parameter.

This is a breaking change that will be part of `v1.0.0`.

Resolves SDK-162.