### PR TITLE
v1.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    workos (0.11.2)
+    workos (1.0.0)
       sorbet-runtime (~> 0.5)
 
 GEM

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 WorkOS
+Copyright (c) 2021 WorkOS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/workos/version.rb
+++ b/lib/workos/version.rb
@@ -2,5 +2,5 @@
 # typed: strong
 
 module WorkOS
-  VERSION = '0.11.2'
+  VERSION = '1.0.0'
 end


### PR DESCRIPTION
## Breaking Changes

- `SSO.profile` has been renamed to `SSO.profile_and_token` (#96)
  - The return type has also been changed from `Profile` to `ProfileAndToken`
- Organization operations have been moved from `Portal` to `Organizations` (#95)
  - `Portal.list_organizations` &rarr; `Organizations.list_organizations`
  - `Portal.get_organization` &rarr; `Organizations.get_organization`
  - `Portal.create_organization` &rarr; `Organizations.create_organization`
  - `Portal.update_organization` &rarr; `Organizations.update_organization`
-  `SSO.create_connection` and `SSO.promote_draft_connection` have been removed (#97)

## Removed Deprecations

- The deprecated `project_id` parameter for `SSO::authorization_url` and `SSO::profile_and_token` (formerly `SSO::profile`) has been fully removed. The `client_id` parameter should be used instead (#94)

Resolves SDK-183.