### PR TITLE
Remove stray `}`

### DIFF
--- a/lib/workos/client.rb
+++ b/lib/workos/client.rb
@@ -48,7 +48,7 @@ module WorkOS
         'Content-Type' => 'application/json',
       )
 
-      request['Authorization'] = "Bearer #{access_token || WorkOS.key!}}" if auth
+      request['Authorization'] = "Bearer #{access_token || WorkOS.key!}" if auth
       request['User-Agent'] = user_agent
       request
     end


### PR DESCRIPTION
While upgrading from WorkOS 1.0.0 to 1.2.0 we found a regression where
our `Authorization` header accidentally had included an extra `}`. After
searching throughout our application to find the typo, we realized it
had snuck in upstream.

This was introduced in #99