### PR TITLE
Support error and error description in the body of an error

### DIFF
--- a/lib/workos/errors.rb
+++ b/lib/workos/errors.rb
@@ -13,12 +13,16 @@ module WorkOS
     sig do
       params(
         message: T.nilable(String),
+        error: T.nilable(String),
+        error_description: T.nilable(String),
         http_status: T.nilable(Integer),
         request_id: T.nilable(String),
       ).void
     end
-    def initialize(message: nil, http_status: nil, request_id: nil)
+    def initialize(message: nil, error: nil, error_description: nil, http_status: nil, request_id: nil)
       @message = message
+      @error = error
+      @error_description = error_description
       @http_status = http_status
       @request_id = request_id
     end
@@ -27,7 +31,12 @@ module WorkOS
     def to_s
       status_string = @http_status.nil? ? '' : "Status #{@http_status}, "
       id_string = @request_id.nil? ? '' : " - request ID: #{@request_id}"
-      "#{status_string}#{@message}#{id_string}"
+      if @error && @error_description
+        error_string = "error: #{@error}, error_description: #{@error_description}"
+        "#{status_string}#{error_string}#{id_string}"
+      else
+        "#{status_string}#{@message}#{id_string}"
+      end
     end
   end
 

--- a/lib/workos/errors.rb
+++ b/lib/workos/errors.rb
@@ -34,6 +34,8 @@ module WorkOS
       if @error && @error_description
         error_string = "error: #{@error}, error_description: #{@error_description}"
         "#{status_string}#{error_string}#{id_string}"
+      elsif @error
+        "#{status_string}#{@error}#{id_string}"
       else
         "#{status_string}#{@message}#{id_string}"
       end

--- a/lib/workos/sso.rb
+++ b/lib/workos/sso.rb
@@ -248,12 +248,15 @@ module WorkOS
       end
 
       sig { params(response: Net::HTTPResponse).void }
+      # rubocop:disable Metrics/MethodLength
       def check_and_raise_profile_and_token_error(response:)
         begin
           body = JSON.parse(response.body)
           return if body['access_token'] && body['profile']
 
           message = body['message']
+          error = body['error']
+          error_description = body['error_description']
           request_id = response['x-request-id']
         rescue StandardError
           message = 'Something went wrong'
@@ -261,10 +264,13 @@ module WorkOS
 
         raise APIError.new(
           message: message,
+          error: error,
+          error_description: error_description,
           http_status: nil,
           request_id: request_id,
         )
       end
+      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/spec/lib/workos/sso_spec.rb
+++ b/spec/lib/workos/sso_spec.rb
@@ -252,7 +252,7 @@ describe WorkOS::SSO do
           to_return(
             headers: { 'X-Request-ID' => 'request-id' },
             status: 422,
-            body: { "message": 'some error message' }.to_json,
+            body: { "error": 'some error', "error_description": 'some error description' }.to_json,
           )
       end
 
@@ -261,7 +261,7 @@ describe WorkOS::SSO do
           described_class.profile_and_token(**args)
         end.to raise_error(
           WorkOS::APIError,
-          'some error message - request ID: request-id',
+          'error: some error, error_description: some error description - request ID: request-id',
         )
       end
     end
@@ -271,11 +271,11 @@ describe WorkOS::SSO do
         stub_request(:post, 'https://api.workos.com/sso/token').
           with(body: request_body).
           to_return(
-            status: 201,
+            status: 400,
             headers: { 'X-Request-ID' => 'request-id' },
             body: {
-              message: "The code '01DVX3C5Z367SFHR8QNDMK7V24'" \
-                ' has expired or is invalid.',
+              "error": 'invalid_grant',
+              "error_description": "The code '01DVX3C5Z367SFHR8QNDMK7V24' has expired or is invalid.",
             }.to_json,
           )
       end
@@ -285,7 +285,7 @@ describe WorkOS::SSO do
           described_class.profile_and_token(**args)
         end.to raise_error(
           WorkOS::APIError,
-          "The code '01DVX3C5Z367SFHR8QNDMK7V24'" \
+          "error: invalid_grant, error_description: The code '01DVX3C5Z367SFHR8QNDMK7V24'" \
           ' has expired or is invalid. - request ID: request-id',
         )
       end


### PR DESCRIPTION
The Ruby SDK currently only supports a `message` in the body of an error, however the API sends an `error` and `error_description` in some error bodies.

We should support both in the error handling.

@maxdeviant this is a first pass at improving the error handling. Let me know if you have thoughts on how to implement it better. Additionally, will all errors that have an `error` in the body also have an `error_description`? Or should we account for the case where there is an `error` but no `error_description`?