### PR TITLE
Fix Thread Safety Issues with `Net::HTTP`

### DIFF
--- a/lib/workos/client.rb
+++ b/lib/workos/client.rb
@@ -9,12 +9,9 @@ module WorkOS
 
     sig { returns(Net::HTTP) }
     def client
-      return @client if defined?(@client)
-
-      @client = Net::HTTP.new(WorkOS::API_HOSTNAME, 443)
-      @client.use_ssl = true
-
-      @client
+      Net::HTTP.new(WorkOS::API_HOSTNAME, 443).tap do |http_client|
+        http_client.use_ssl = true
+      end
     end
 
     sig do

--- a/spec/lib/workos/audit_trail_spec.rb
+++ b/spec/lib/workos/audit_trail_spec.rb
@@ -2,6 +2,8 @@
 # typed: false
 
 describe WorkOS::AuditTrail do
+  it_behaves_like 'client'
+
   describe '.create_event' do
     context 'with valid event payload' do
       let(:valid_event) do

--- a/spec/lib/workos/directory_sync_spec.rb
+++ b/spec/lib/workos/directory_sync_spec.rb
@@ -2,6 +2,8 @@
 # typed: false
 
 describe WorkOS::DirectorySync do
+  it_behaves_like 'client'
+
   describe '.list_directories' do
     context 'with no options' do
       it 'returns directories and metadata' do

--- a/spec/lib/workos/organizations_spec.rb
+++ b/spec/lib/workos/organizations_spec.rb
@@ -2,6 +2,8 @@
 # typed: false
 
 describe WorkOS::Organizations do
+  it_behaves_like 'client'
+
   describe '.create_organization' do
     context 'with valid payload' do
       it 'creates an organization' do

--- a/spec/lib/workos/passwordless_spec.rb
+++ b/spec/lib/workos/passwordless_spec.rb
@@ -2,6 +2,8 @@
 # typed: false
 
 describe WorkOS::Passwordless do
+  it_behaves_like 'client'
+
   describe '.create_session' do
     context 'with valid options payload' do
       let(:valid_options) do

--- a/spec/lib/workos/portal_spec.rb
+++ b/spec/lib/workos/portal_spec.rb
@@ -2,6 +2,8 @@
 # typed: false
 
 describe WorkOS::Portal do
+  it_behaves_like 'client'
+
   describe '.generate_link' do
     let(:organization) { 'org_01EHQMYV6MBK39QC5PZXHY59C3' }
 

--- a/spec/lib/workos/sso_spec.rb
+++ b/spec/lib/workos/sso_spec.rb
@@ -4,6 +4,8 @@
 require 'securerandom'
 
 describe WorkOS::SSO do
+  it_behaves_like 'client'
+
   describe '.authorization_url' do
     context 'with a domain' do
       let(:args) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,9 @@ require 'webmock/rspec'
 require 'workos'
 require 'vcr'
 
+# Support
+Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
+
 SPEC_ROOT = File.dirname __FILE__
 
 VCR.configure do |config|

--- a/spec/support/shared_examples/client_spec.rb
+++ b/spec/support/shared_examples/client_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+# typed: false
+
+RSpec.shared_examples 'client' do
+  subject(:client) { described_class.client }
+
+  it { is_expected.to be_kind_of(Net::HTTP) }
+
+  it 'assigns use_ssl' do
+    expect(client.use_ssl?).to be true
+  end
+
+  it 'returns new instance' do
+    expect(described_class.client.object_id).to_not eq described_class.client.object_id
+  end
+end


### PR DESCRIPTION
`Net::HTTP` [is not thread safe](https://stackoverflow.com/questions/3063088/is-rubys-nethttp-threadsafe), therefore memoization will potentially lead to issues when the code is run in a multi threaded environment (e.g Puma server with multiple workers). 

This PR amends the Client behaviour to return a new instance of `Net::HTTP` on each request.