### PR TITLE
Add Microsoft as a provider enum

### DIFF
--- a/lib/workos/types/provider_enum.rb
+++ b/lib/workos/types/provider_enum.rb
@@ -8,6 +8,7 @@ module WorkOS
     class Provider < T::Enum
       enums do
         Google = new('GoogleOAuth')
+        Microsoft = new('MicrosoftOAuth')
       end
     end
   end


### PR DESCRIPTION
Currently the only provider enum supported is google (GoogleOAuth), this PR is to add microsoft (MicrosoftOAuth).