### PR TITLE
Add MicrosoftOAuth as a provider

### DIFF
--- a/lib/workos/types/provider_enum.rb
+++ b/lib/workos/types/provider_enum.rb
@@ -8,6 +8,7 @@ module WorkOS
     class Provider < T::Enum
       enums do
         Google = new('GoogleOAuth')
+        Microsoft = new('MicrosoftOAuth')
       end
     end
   end


### PR DESCRIPTION
Enable 'MicrosoftOAuth' as a valid provider for the SSO Authorization URL. Reference: https://workos.com/docs/sso/guide/add-to-your-app/add-an-endpoint-to-initiate-sso