### PR TITLE
Make `organization_id` nullable

### DIFF
--- a/lib/workos/connection.rb
+++ b/lib/workos/connection.rb
@@ -21,7 +21,7 @@ module WorkOS
       @name = T.let(raw.name, String)
       @connection_type = T.let(raw.connection_type, String)
       @domains = T.let(raw.domains, Array)
-      @organization_id = T.let(raw.organization_id, String)
+      @organization_id = raw.organization_id
       @state = T.let(raw.state, String)
       @status = T.let(raw.status, String)
       @created_at = T.let(raw.created_at, String)

--- a/lib/workos/directory.rb
+++ b/lib/workos/directory.rb
@@ -20,7 +20,7 @@ module WorkOS
       @domain = T.let(raw.domain, String)
       @type = T.let(raw.type, String)
       @state = T.let(raw.state, String)
-      @organization_id = T.let(raw.organization_id, String)
+      @organization_id = raw.organization_id
       @created_at = T.let(raw.created_at, String)
       @updated_at = T.let(raw.updated_at, String)
     end

--- a/lib/workos/profile.rb
+++ b/lib/workos/profile.rb
@@ -23,7 +23,7 @@ module WorkOS
       @email = T.let(raw.email, String)
       @first_name = raw.first_name
       @last_name = raw.last_name
-      @organization_id = T.let(raw.organization_id, String)
+      @organization_id = raw.organization_id
       @connection_id = T.let(raw.connection_id, String)
       @connection_type = T.let(raw.connection_type, String)
       @idp_id = raw.idp_id

--- a/lib/workos/types/connection_struct.rb
+++ b/lib/workos/types/connection_struct.rb
@@ -10,7 +10,7 @@ module WorkOS
       const :name, String
       const :connection_type, String
       const :domains, T::Array[T.untyped]
-      const :organization_id, String
+      const :organization_id, T.nilable(String)
       const :state, String
       const :status, String
       const :created_at, String

--- a/lib/workos/types/directory_struct.rb
+++ b/lib/workos/types/directory_struct.rb
@@ -11,7 +11,7 @@ module WorkOS
       const :domain, String
       const :type, String
       const :state, String
-      const :organization_id, String
+      const :organization_id, T.nilable(String)
       const :created_at, String
       const :updated_at, String
     end

--- a/lib/workos/types/profile_struct.rb
+++ b/lib/workos/types/profile_struct.rb
@@ -10,7 +10,7 @@ module WorkOS
       const :email, String
       const :first_name, T.nilable(String)
       const :last_name, T.nilable(String)
-      const :organization_id, String
+      const :organization_id, T.nilable(String)
       const :connection_id, String
       const :connection_type, String
       const :idp_id, T.nilable(String)


### PR DESCRIPTION
This PR makes the `organization_id` field nullable on the following objects in preparation for future changes:

- `Connection`
- `Directory`
- `Profile`

This is a breaking change, so we'll need to bump the major version.

Resolves SDK-309.