### PR TITLE
v2.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    workos (1.6.1)
+    workos (2.0.0)
       sorbet-runtime (~> 0.5)
 
 GEM

--- a/lib/workos/version.rb
+++ b/lib/workos/version.rb
@@ -2,5 +2,5 @@
 # typed: strong
 
 module WorkOS
-  VERSION = '1.6.1'
+  VERSION = '2.0.0'
 end


### PR DESCRIPTION
## Breaking Changes

- The `organization_id` field on the following objects is now nullable (#129):
  - `Connection`
  - `Directory`
  - `Profile`

## New Features

- Added `DirectorySync.get_directory` for retrieving a Directory by its ID (#132)