### PR TITLE
Add full type for `get_timestamp_and_signature_hash`

### DIFF
--- a/lib/workos/webhooks.rb
+++ b/lib/workos/webhooks.rb
@@ -108,7 +108,7 @@ module WorkOS
       sig do
         params(
           sig_header: String,
-        ).returns(T::Array[T.untyped])
+        ).returns([String, String])
       end
       def get_timestamp_and_signature_hash(
         sig_header:


### PR DESCRIPTION
Noticed that we were losing some type-safety due to the usage of `T.untyped`. Sorbet has support for [Tuple types](https://sorbet.org/docs/tuples), so we can use that instead here.

This shouldn't affect the runtime behavior.